### PR TITLE
Mentimeter as a notebook quiz option

### DIFF
--- a/Indaba_2022_Prac_Template.ipynb
+++ b/Indaba_2022_Prac_Template.ipynb
@@ -110,8 +110,7 @@
       },
       "outputs": [],
       "source": [
-        "selection = 'a' #@param [\"a\", \"b\", \"c\"]\n",
-        "print(f\"You selected: {selection}\")"
+        "#@title Go to www.menti.com and use the code 8371 2006"
       ]
     },
     {

--- a/Indaba_2022_Prac_Template.ipynb
+++ b/Indaba_2022_Prac_Template.ipynb
@@ -110,7 +110,13 @@
       },
       "outputs": [],
       "source": [
-        "#@title Go to www.menti.com and use the code 8371 2006"
+        "#@title Will the gradient for line A, be negative or positive?  Go to www.menti.com and use the code 8371 2006.\n",
+        "from IPython.display import HTML\n",
+        "HTML(\n",
+        "\"\"\"\n",
+        "<img src=\"https://mammothmemory.net/images/user/base/Maths/Graphs/Formula%20For%20Straight%20Lines/positive-and-negative-gradient-lines-on-a-graph.8112cb9.jpg\" alt=\"Italian Trulli\"></img>\n",
+        "\"\"\"\n",
+        ")"
       ]
     },
     {


### PR DESCRIPTION
A very simple example of how we can put in a [mentimeter](https://www.mentimeter.com/) multiple choice question within the notebooks. This will allow us to see in real time how many people have answered the question and what the overall score is within the group. 

Not ideal, especially if the question is more advanced, but it meets a bit of the requirements we mentioned in the meeting on Monday. 

Mentimeter also free.

To see how a question can be asked, go to www.menti.com and use the code 8371 2006